### PR TITLE
Avoid conflict with popular maven central repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
     </build>
     <repositories>
         <repository>
-            <id>central</id>
+            <id>jcenter</id>
             <name>jcenter</name>
             <url>http://jcenter.bintray.com</url>
         </repository>


### PR DESCRIPTION
Central generally means - https://repo1.maven.org/maven2/

In my case, I am behind a mirror which uses central to use above. 
Hence the build always fails unable to find the dependencies.


